### PR TITLE
Set default value of click event

### DIFF
--- a/streamlit_card/__init__.py
+++ b/streamlit_card/__init__.py
@@ -25,7 +25,7 @@ def card(
     text: Union[str, List[str]],
     image: Optional[str] = None,
     url: Optional[str] = None,
-    on_click: Callable[[Any], Any] = None,
+    on_click: Callable[[Any], Any] = lambda: None,
     styles: Optional[Dict[str, Any]] = {"card": {}, "text": {}},
     key: Optional[str] = None,
 ) -> bool:


### PR DESCRIPTION
This PR suppresses `TypeError: 'NoneType' object is not callable` error when both `url` and `on_click` are not provided.
