### PR TITLE
Added a way to use a percentage as width parameter for card CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ res = card(
 )
 ```
 
+If you want to set the size of as if you put `use_column_width=True`, do this:
+```py
+from streamlit_card import card
+
+res = card(
+    title="Streamlit Card",
+    text="This is a test card",
+    image="https://placekitten.com/500/500",
+    styles={
+        "card": {
+            "width": "100%", # <- make the card use the width of its container, note that it will not resize the height of the card automatically
+            "height": "300px" # <- if you want to set the card height to 300px
+            ...
+        }
+    }
+)
+```
+
 If you want to modify the filter applied to the image, you could do this:
 ```py
 from streamlit_card import card
@@ -114,12 +132,14 @@ res = card(
             ...
         },
         "filter": {
-            "background-color": "rgba(0, 0, 0, 0)"   <- make the image not dimmed anymore
+            "background-color": "rgba(0, 0, 0, 0)"  # <- make the image not dimmed anymore
             ...
         }
     }
 )
 ```
+
+The editable CSS are "card", "title", "text", "filter" and "div".
 
 ## Multiple descriptions
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ res = card(
 )
 ```
 
-If you want to set the size of as if you put `use_column_width=True`, do this:
+If you want to set the size of as `use_column_width=True`, do this:
 ```py
 from streamlit_card import card
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ res = card(
 )
 ```
 
-The editable CSS are "card", "title", "text", "filter" and "div".
+The editable CSS are `"card"`, `"title"`, `"text"`, `"filter"` and `"div"`.
 
 ## Multiple descriptions
 

--- a/streamlit_card/__init__.py
+++ b/streamlit_card/__init__.py
@@ -50,6 +50,6 @@ def card(
         styles=styles,
         default=False,
     )
-    if clicked and on_click is not None:
+    if clicked:
         on_click()
     return clicked

--- a/streamlit_card/__init__.py
+++ b/streamlit_card/__init__.py
@@ -50,6 +50,6 @@ def card(
         styles=styles,
         default=False,
     )
-    if clicked:
+    if clicked and on_click is not None:
         on_click()
     return clicked

--- a/streamlit_card/frontend/src/stCard.tsx
+++ b/streamlit_card/frontend/src/stCard.tsx
@@ -60,17 +60,22 @@ class Card extends StreamlitComponentBase {
         ...styles.card,
       },
       `
+      & {
+        transform: scale(0.95);
+      }
       &:hover {
-        box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.4);
+        transform: scale(1);
       }
       &:active {
-        box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.7);
+        transform: scale(0.95);
       }
       `
     );
 
     const Parent = styled.div({
-      padding: margin
+      padding: margin,
+      width: "100%",
+      ...styles.div,
     });
 
     const Title = styled.h2({
@@ -78,7 +83,7 @@ class Card extends StreamlitComponentBase {
       zIndex: "2",
       fontSize: "2em",
       fontWeight: "bolder",
-      ...styles.text,
+      ...styles.title,
     });
 
     const Text = styled.p({


### PR DESCRIPTION
Allow the CSS of the card to use a percentage as width parameter and so, be able to "add a way" to do `use_column_width=True` (https://github.com/gamcoh/st-card/issues/19) like here:
```py
from streamlit_card import card

res = card(
    title="Streamlit Card",
    text="This is a test card",
    image="https://placekitten.com/500/500",
    styles={
        "card": {
            "width": "100%", # <- make the card use the width of its container, note that it will not resize the height of the card automatically
            "height": "300px" # <- if you want to set the card height to 300px
            ...
        }
    }
)
```
Also change the animation and split the CSS of the text and the title. 