### PR TITLE
Allow empty backgroundImage property on cards in TSX

### DIFF
--- a/streamlit_card/frontend/src/stCard.tsx
+++ b/streamlit_card/frontend/src/stCard.tsx
@@ -41,7 +41,7 @@ class Card extends StreamlitComponentBase {
         height: `${height}px`,
         borderRadius: "20px",
         overflow: "hidden",
-        backgroundImage: `url(${image})`,
+        backgroundImage: image ? `url(${image})` : "none",
         backgroundPosition: "center",
         backgroundSize: "cover",
         backgroundRepeat: "no-repeat",


### PR DESCRIPTION
If no image is used, as in this text_card: 

```py
import streamlit as st
from streamlit_card import card

st.title('Fix st_card')

image_card = card(
  title="Image card",
  text="Text & Image",
  image="http://placekitten.com/200/300",
)

text_card = card(
  title="No Image card",
  text="Just text"
)
```


This error is returned:

```sh
File "./venv/lib/python3.9/site-packages/streamlit/web/server/component_request_handler.py", line 51, in get
    with open(abspath, "rb") as file:
FileNotFoundError: [Errno 2] No such file or directory: './venv/lib/python3.9/site-packages/streamlit_card/frontend/build/null'
```

This PR addresses that error by setting the default backgroundImage property to `none` in TSX, if no image is provided in Python. 

Tagging https://github.com/gamcoh/st-card/issues/25